### PR TITLE
Fix: Reduce transient memory usage in GetLogs API

### DIFF
--- a/loggingutils.go
+++ b/loggingutils.go
@@ -76,6 +76,9 @@ func (s *Server) loadAllLogs(ctx context.Context, origin string, match string, i
 				for _, log := range nlogs {
 					if match == "" || strings.Contains(log.GetLog(), match) {
 						logs = append(logs, log)
+						if len(logs) >= 20 {
+							return filepath.SkipDir
+						}
 					}
 				}
 			}
@@ -100,6 +103,9 @@ func (s *Server) loadAllLogs(ctx context.Context, origin string, match string, i
 					for _, log := range dlogs {
 						if match == "" || strings.Contains(log.GetLog(), match) {
 							logs = append(logs, log)
+							if len(logs) >= 20 {
+								return filepath.SkipDir
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Optimized the loadAllLogs function to prevent excessive transient memory
allocation when handling GetLogs API requests. Previously, the function
would load all matching log entries into memory before applying the
limit of 20 logs.

This change introduces an early exit condition within the filepath.Walk
loops, ensuring that log processing stops as soon as 20 relevant log
entries are collected. This significantly reduces memory pressure and
improves performance, especially when dealing with large log files and
frequent GetLogs requests.

Closes #1147